### PR TITLE
feat: add cross-platform system notifications support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mcp-sys-bridge"
-version = "0.1.4"
-description = "An implementation of the Model Context Protocol (MCP), acting as a simple bridge to native OS functionalities like clipboard management and URL handling."
+version = "0.1.5"
+description = "An implementation of the Model Context Protocol (MCP), acting as a simple bridge to native OS functionalities like clipboard management, URL handling, and system notifications."
 authors = [
     { name = "Leynier Gutiérrez González", email = "leynier41@gmail.com" },
 ]
@@ -38,7 +38,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 
-dependencies = ["fastmcp>=2.7.0", "pydantic>=2.11.5", "pyperclip>=1.9.0"]
+dependencies = ["fastmcp>=2.7.0", "plyer>=2.1.0", "pydantic>=2.11.5", "pyperclip>=1.9.0"]
 
 [dependency-groups]
 dev = ["ruff>=0.11.13"]

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ A bridge implementation of the **Model Context Protocol (MCP)** that exposes nat
 
 * 🚀 **URL Opening** — open one or multiple URLs in the default browser.
 * 📋 **Clipboard Support** — copy text directly to the clipboard.
+* 🔔 **System Notifications** — send native OS notifications (Windows, macOS, Linux).
 * 📆 **Date Info** — retrieve detailed information about the current date and time.
 
 ---
@@ -73,11 +74,17 @@ uvx mcp-sys-bridge
 
 - `open_urls` — open a list of URLs in the default browser.
 - `copy_to_clipboard` — copy text to the clipboard.
+- `send_notification` — send a native system notification with customizable title, message, app name, icon, and timeout.
 - `get_current_date_info` — return rich information about the current date such as day number, week number, quarter and more.
 
 ---
 
 ## Changelog
+
+### 0.1.5
+
+- Added `send_notification` tool to send native system notifications across Windows, macOS, and Linux.
+- Added `plyer` dependency for cross-platform notification support.
 
 ### 0.1.4
 

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ uvx mcp-sys-bridge
 
 - `open_urls` — open a list of URLs in the default browser.
 - `copy_to_clipboard` — copy text to the clipboard.
-- `send_notification` — send a native system notification with customizable title, message, app name, icon, and timeout.
+- `send_notification` — send a native system notification with customizable title, message, app name, and timeout.
 - `get_current_date_info` — return rich information about the current date such as day number, week number, quarter and more.
 
 ---

--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, urlunparse
 import pyperclip
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from plyer import notification
 
 from .models import DateInfo
 
@@ -47,6 +48,54 @@ def copy_to_clipboard(text: str) -> str:
         return "Text copied to clipboard successfully."
     except Exception as e:
         return f"Error copying text to clipboard: {e}"
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False))
+def send_notification(
+    title: str,
+    message: str,
+    app_name: str | None = None,
+    app_icon: str | None = None,
+    timeout: int = 10,
+) -> str:
+    """
+    Send a system notification.
+
+    Displays a native operating system notification with the specified title and message.
+    Works across Windows, macOS, and Linux platforms.
+
+    Args:
+        title: The title of the notification (required)
+        message: The message body of the notification (required)
+        app_name: The name of the application sending the notification (optional)
+        app_icon: Path to an icon file to display with the notification (optional).
+                  On Windows, must be a .ico file. On macOS and Linux, supports .png, .jpg, etc.
+        timeout: Duration in seconds to display the notification (default: 10)
+
+    Returns:
+        A success message if the notification was sent successfully, or an error message if it failed.
+
+    Examples:
+        send_notification("Task Complete", "Your build has finished successfully")
+        send_notification("Warning", "Low disk space detected", app_name="System Monitor", timeout=5)
+    """
+    try:
+        notification_params = {
+            "title": title,
+            "message": message,
+            "timeout": timeout,
+        }
+
+        if app_name:
+            notification_params["app_name"] = app_name
+
+        if app_icon:
+            notification_params["app_icon"] = app_icon
+
+        notification.notify(**notification_params)
+        return f"Notification sent successfully: '{title}'"
+    except Exception as e:
+        return f"Error sending notification: {e}"
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/server.py
+++ b/src/server.py
@@ -55,7 +55,6 @@ def send_notification(
     title: str,
     message: str,
     app_name: str | None = None,
-    app_icon: str | None = None,
     timeout: int = 10,
 ) -> str:
     """
@@ -68,8 +67,6 @@ def send_notification(
         title: The title of the notification (required)
         message: The message body of the notification (required)
         app_name: The name of the application sending the notification (optional)
-        app_icon: Path to an icon file to display with the notification (optional).
-                  On Windows, must be a .ico file. On macOS and Linux, supports .png, .jpg, etc.
         timeout: Duration in seconds to display the notification (default: 10)
 
     Returns:
@@ -88,9 +85,6 @@ def send_notification(
 
         if app_name:
             notification_params["app_name"] = app_name
-
-        if app_icon:
-            notification_params["app_icon"] = app_icon
 
         notification.notify(**notification_params)
         return f"Notification sent successfully: '{title}'"

--- a/src/server.py
+++ b/src/server.py
@@ -50,7 +50,7 @@ def copy_to_clipboard(text: str) -> str:
         return f"Error copying text to clipboard: {e}"
 
 
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False))
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 def send_notification(
     title: str,
     message: str,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -259,6 +259,7 @@ version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "plyer" },
     { name = "pydantic" },
     { name = "pyperclip" },
 ]
@@ -271,6 +272,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.7.0" },
+    { name = "plyer", specifier = ">=2.1.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pyperclip", specifier = ">=1.9.0" },
 ]
@@ -297,6 +299,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "plyer"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/85/f61425aa9be1f9108eec1c13861c1e11c9a04eb786eb4832a8f7188317df/plyer-2.1.0.tar.gz", hash = "sha256:65b7dfb7e11e07af37a8487eb2aa69524276ef70dad500b07228ce64736baa61", size = 121371, upload-time = "2022-11-12T13:36:48.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/89/a41c2643fc8eabeb84791acb9d0e4d139b1e4b53473cc4dae947b5fa33ed/plyer-2.1.0-py2.py3-none-any.whl", hash = "sha256:1b1772060df8b3045ed4f08231690ec8f7de30f5a004aa1724665a9074eed113", size = 142266, upload-time = "2022-11-12T13:36:47.181Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -255,7 +255,7 @@ wheels = [
 
 [[package]]
 name = "mcp-sys-bridge"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds native system notification support to MCP System Bridge, allowing AI models to send desktop notifications across Windows, macOS, and Linux platforms.

## Changes

- ✅ New `send_notification` tool using `plyer` library
- ✅ Cross-platform support (Windows, macOS, Linux)
- ✅ Configurable parameters: title, message, app_name, timeout
- ✅ Version bumped to 0.1.5
- ✅ Updated README and changelog

## Implementation Details

- **Library**: `plyer>=2.1.0` for cross-platform notifications
- **API**: Simple synchronous interface compatible with MCP/STDIO

## Platform Requirements

- **Windows**: Works out-of-the-box
- **macOS**: Works out-of-the-box
- **Linux**: Requires `notify-send` or `python3-dbus`

## Example Usage

```python
send_notification(
    title="Build Complete",
    message="Your project compiled successfully",
    app_name="MCP System Bridge",
    timeout=10
)
```